### PR TITLE
Endpoints for saving / getting decks

### DIFF
--- a/prisma/migrations/20220601040223_add_saved_deck_skeleton/migration.sql
+++ b/prisma/migrations/20220601040223_add_saved_deck_skeleton/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `skeleton` to the `SavedDeck` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "SavedDeck" ADD COLUMN     "skeleton" JSONB NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model SavedDeck {
   name      String
   user      User     @relation(fields: [userUid], references: [uid])
   userUid   String   @db.VarChar(255)
+  skeleton  Json
 }
 
 model GameResult {

--- a/src/endpoints/savedDecks/index.ts
+++ b/src/endpoints/savedDecks/index.ts
@@ -1,0 +1,1 @@
+export * from './savedDecks';

--- a/src/endpoints/savedDecks/savedDecks.ts
+++ b/src/endpoints/savedDecks/savedDecks.ts
@@ -1,0 +1,63 @@
+import { Request, Response, Express } from 'express';
+
+import { Prisma, PrismaClient, SavedDeck } from '@prisma/client';
+
+export const initializeSavedDeckEndpoints = (
+  server: Express,
+  prisma: PrismaClient
+) => {
+  server.get(
+    '/saved_decks/:username',
+    async (
+      req: Request<{ username: string }, SavedDeck[] | ErrorMessage, EmptyObj>,
+      res: Response<SavedDeck[] | ErrorMessage>
+    ): Promise<Response<SavedDeck[] | ErrorMessage>> => {
+      const { username } = req.params;
+
+      if (!username)
+        return res.status(400).send({ message: 'Need a username' });
+
+      const savedDecks = await prisma.savedDeck.findMany({
+        where: { user: { username } },
+      });
+      return res.send(savedDecks);
+    }
+  );
+
+  server.post(
+    '/saved_decks/:username',
+    async (
+      req: Request<
+        { username: string },
+        SavedDeck | ErrorMessage,
+        { deckName: string; skeleton: Prisma.JsonArray }
+      >,
+      res: Response<SavedDeck | ErrorMessage>
+    ): Promise<Response<SavedDeck | ErrorMessage>> => {
+      const { username } = req.params;
+      const { deckName, skeleton } = req.body;
+
+      if (!username)
+        return res.status(400).send({ message: 'Need a username' });
+      if (!deckName)
+        return res.status(400).send({ message: 'Need a deck name' });
+      if (!skeleton || !Array.isArray(skeleton))
+        return res
+          .status(400)
+          .send({ message: 'Need a deck skeleton in JSON form' });
+
+      const user = await prisma.user.findFirst({ where: { username } });
+      if (!user)
+        return res.status(400).send({ message: 'No matching user found' });
+
+      const newDeck = await prisma.savedDeck.create({
+        data: {
+          userUid: user.uid,
+          name: deckName,
+          skeleton,
+        },
+      });
+      return res.send(newDeck);
+    }
+  );
+};

--- a/src/endpoints/users/index.ts
+++ b/src/endpoints/users/index.ts
@@ -1,0 +1,1 @@
+export * from './users';

--- a/src/endpoints/users/users.ts
+++ b/src/endpoints/users/users.ts
@@ -1,0 +1,101 @@
+import { Request, Response, Express } from 'express';
+
+import { Prisma, PrismaClient, User } from '@prisma/client';
+
+export const initializeUserEndpoints = (
+  server: Express,
+  prisma: PrismaClient
+) => {
+  server.get(
+    '/users',
+    async (
+      _: Request<EmptyObj, User[], EmptyObj>,
+      res: Response<User[]>
+    ): Promise<Response<User[]>> => {
+      const users = await prisma.user.findMany();
+      return res.send(users);
+    }
+  );
+
+  interface NewUserRequestBodyParams {
+    uid: string;
+    username: string;
+  }
+
+  server.post(
+    '/users/new_user',
+    async (
+      req: Request<EmptyObj, User | ErrorMessage, NewUserRequestBodyParams>,
+      res: Response<User | ErrorMessage>
+    ): Promise<Response<User | ErrorMessage>> => {
+      const { username, uid } = req.body;
+      if (!username || !uid)
+        return res
+          .status(400)
+          .send({ message: 'Need both a username and a uid' });
+      // TODO: add unit tests
+      // TODO: add auth0 layer
+      try {
+        const user = await prisma.user.create({ data: { username, uid } });
+        return res.send(user);
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          return res
+            .status(400)
+            .send({ message: 'A user with this uid already exists' });
+        }
+
+        return res
+          .status(400)
+          .send({ message: 'Something went wrong in creating a user' });
+      }
+    }
+  );
+
+  server.delete(
+    '/users/:uid',
+    async (
+      req: Request<{ uid: string }, User | ErrorMessage, EmptyObj>,
+      res: Response<User | ErrorMessage>
+    ): Promise<Response<User | ErrorMessage>> => {
+      const { uid } = req.params;
+
+      if (!uid) return res.status(400).send({ message: 'Need a uid' });
+      // TODO: add unit tests
+      // TODO: add auth0 layer
+      try {
+        const deleteUser = prisma.user.delete({
+          where: {
+            uid,
+          },
+        });
+        const deleteDecks = prisma.savedDeck.deleteMany({
+          where: {
+            userUid: uid,
+          },
+        });
+        await prisma.$transaction([deleteUser, deleteDecks]);
+
+        return res.send({ message: 'Success' });
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          return res
+            .status(400)
+            .send({ message: 'A user with this uid already exists' });
+        }
+
+        return res.status(400).send({
+          message: `Something went wrong in deleting a user: ${JSON.stringify(
+            error
+          )}`,
+        });
+      }
+    }
+  );
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,12 @@
 import express, { Request, Response } from 'express';
 
-import { Prisma, PrismaClient, User } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+import { initializeUserEndpoints } from './endpoints/users';
+import { initializeSavedDeckEndpoints } from './endpoints/savedDecks';
 
 const prisma = new PrismaClient();
 
 export const server = express();
-
-type ErrorMessage = {
-  message: string;
-};
-
-type EmptyObj = Record<string, never>;
 
 // Middlewares
 server.use(express.json());
@@ -22,52 +18,5 @@ server.get('/', (_: Request, res: Response) => {
   });
 });
 
-// User endpoints
-server.get(
-  '/users',
-  async (
-    _: Request<EmptyObj, User[], EmptyObj>,
-    res: Response<User[]>
-  ): Promise<Response<User[]>> => {
-    const users = await prisma.user.findMany();
-    return res.send(users);
-  }
-);
-
-interface NewUserRequestBodyParams {
-  uid: string;
-  username: string;
-}
-
-server.post(
-  '/users/new_user',
-  async (
-    req: Request<EmptyObj, User, NewUserRequestBodyParams>,
-    res: Response<User | ErrorMessage>
-  ): Promise<Response<User | ErrorMessage>> => {
-    const { username, uid } = req.body;
-    if (!username || !uid)
-      return res
-        .status(400)
-        .send({ message: 'Need both a username and a uid' });
-    // TODO: add unit tests
-    // TODO: add auth0 layer
-    try {
-      const user = await prisma.user.create({ data: { username, uid } });
-      return res.send(user);
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        return res
-          .status(400)
-          .send({ message: 'A user with this uid already exists' });
-      }
-
-      return res
-        .status(400)
-        .send({ message: 'Something went wrong in creating a user' });
-    }
-  }
-);
+initializeUserEndpoints(server, prisma);
+initializeSavedDeckEndpoints(server, prisma);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,5 @@
+type ErrorMessage = {
+  message: string;
+};
+
+type EmptyObj = Record<string, never>;


### PR DESCRIPTION
- also: reorganize the way we group endpoint code
- also: add skeleton field to deck model in Prisma
- also: code for deleting a user

Part of work for #9 and #7 

<img width="1365" alt="Screen Shot 2022-06-01 at 12 20 23 AM" src="https://user-images.githubusercontent.com/1839462/171326819-64e0bade-d3a0-450e-909a-7cab0068751f.png">

<img width="1486" alt="Screen Shot 2022-06-01 at 12 20 39 AM" src="https://user-images.githubusercontent.com/1839462/171326850-78c33f09-acc3-4893-ba89-c6ef14dff2d4.png">

<img width="1272" alt="Screen Shot 2022-06-01 at 12 20 58 AM" src="https://user-images.githubusercontent.com/1839462/171326873-1e1a2ed2-cfa7-47ff-af1e-42e3c4d3daf5.png">


