### PR TITLE
Make GET saved decks use params instead of body

### DIFF
--- a/src/endpoints/savedDecks/savedDecks.ts
+++ b/src/endpoints/savedDecks/savedDecks.ts
@@ -7,7 +7,7 @@ export const initializeSavedDeckEndpoints = (
   prisma: PrismaClient
 ) => {
   server.get(
-    '/saved_decks',
+    '/saved_decks/:username',
     async (
       req: Request<{ username: string }, SavedDeck[] | ErrorMessage, EmptyObj>,
       res: Response<SavedDeck[] | ErrorMessage>

--- a/src/endpoints/savedDecks/savedDecks.ts
+++ b/src/endpoints/savedDecks/savedDecks.ts
@@ -9,10 +9,10 @@ export const initializeSavedDeckEndpoints = (
   server.get(
     '/saved_decks',
     async (
-      req: Request<EmptyObj, SavedDeck[] | ErrorMessage, { username: string }>,
+      req: Request<{ username: string }, SavedDeck[] | ErrorMessage, EmptyObj>,
       res: Response<SavedDeck[] | ErrorMessage>
     ): Promise<Response<SavedDeck[] | ErrorMessage>> => {
-      const { username } = req.body;
+      const { username } = req.params;
 
       if (!username)
         return res.status(400).send({ message: 'Need a username' });


### PR DESCRIPTION
In implementing axios / SWR, I found that I overlooked the fact that GET requests should NOT have body's attached to them: [source](https://stackoverflow.com/questions/52561124/body-data-not-sent-in-axios-request)

This fixes that oversight by making the get saved deck endpoint take a username param explicitly, e.g. http://localhost:5001/saved_decks/bulbasaur